### PR TITLE
Support for a dead letter queue.

### DIFF
--- a/sqs_with_iam/main.tf
+++ b/sqs_with_iam/main.tf
@@ -2,11 +2,12 @@ data "template_file" "redrive_policy" {
   template = <<EOF
 {
   "deadLetterTargetArn":"$${dlq}",
-  "maxReceiveCount":5
+  "maxReceiveCount":$${mrc}
 }
 EOF
   vars {
     dlq = "${var.dead_letter_queue}"
+    mrc = "${var.max_receive_count}"
   }
 }
 

--- a/sqs_with_iam/main.tf
+++ b/sqs_with_iam/main.tf
@@ -1,3 +1,15 @@
+data "template_file" "redrive_policy" {
+  template = <<EOF
+{
+  "deadLetterTargetArn":"$${dlq}",
+  "maxReceiveCount":5
+}
+EOF
+  vars {
+    dlq = "${var.dead_letter_queue}"
+  }
+}
+
 resource "aws_sqs_queue" "queue" {
   name                       = "${var.environment}_${var.project}_${var.name}"
   visibility_timeout_seconds = "${var.visibility_timeout_seconds}"
@@ -5,4 +17,5 @@ resource "aws_sqs_queue" "queue" {
   max_message_size           = "${var.max_message_size}"                       # 256 KB
   message_retention_seconds  = "${var.message_retention_seconds}"              # 4 days
   receive_wait_time_seconds  = "${var.receive_wait_time_seconds}"
+  redrive_policy = "${length(var.dead_letter_queue) > 0 ? data.template_file.redrive_policy.rendered : ""}"
 }

--- a/sqs_with_iam/variables.tf
+++ b/sqs_with_iam/variables.tf
@@ -28,3 +28,8 @@ variable "receive_wait_time_seconds" {
   description = "The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning. An integer from 0 to 20 (seconds). The default for this attribute is 0, meaning that the call will return immediately."
   default     = "20"
 }
+
+variable "dead_letter_queue" {
+  description = "The dead letter queue to use for undeliverable messages"
+  default = ""
+}

--- a/sqs_with_iam/variables.tf
+++ b/sqs_with_iam/variables.tf
@@ -33,3 +33,8 @@ variable "dead_letter_queue" {
   description = "The dead letter queue to use for undeliverable messages"
   default = ""
 }
+
+variable "max_receive_count" {
+  description = "Maximum receive count"
+  default = "5"
+}


### PR DESCRIPTION
TF example of an SQS queue pointing to a dead letter queue:

```
module "smartschool-sync-failures" {
  source = "../../../../terraform-sqs/sqs_with_iam"
  environment = "${terraform.env}"
  project = "${var.project}"
  name = "smartschool_school_sync_failures"
}

module "smartschool-sync" {
  #source = "github.com/skyscrapers/terraform-sqs//sqs_with_iam?ref=1beb975b6935a17dd5c3a60960eca114eb8720d5"
  source = "../../../../terraform-sqs/sqs_with_iam"
  environment = "${terraform.env}"
  project = "${var.project}"
  name = "smartschool_school_sync"
  dead_letter_queue = "${module.smartschool-sync-failures.arn}"
}
```

TF plan output for an example, ignoring the IAM resources:

```
+ module.smartschool-sync-failures.aws_sqs_queue.queue
    arn:                         "<computed>"
    content_based_deduplication: "false"
    delay_seconds:               "0"
    fifo_queue:                  "false"
    max_message_size:            "262144"
    message_retention_seconds:   "345600"
    name:                        "staging_polpo_smartschool_school_sync_failures"
    policy:                      "<computed>"
    receive_wait_time_seconds:   "20"
    visibility_timeout_seconds:  "30"

+ module.smartschool-sync.aws_sqs_queue.queue
    arn:                         "<computed>"
    content_based_deduplication: "false"
    delay_seconds:               "0"
    fifo_queue:                  "false"
    max_message_size:            "262144"
    message_retention_seconds:   "345600"
    name:                        "staging_polpo_smartschool_school_sync"
    policy:                      "<computed>"
    receive_wait_time_seconds:   "20"
    redrive_policy:              "${length(var.dead_letter_queue) > 0 ? data.template_file.redrive_policy.rendered : \"\"}"
    visibility_timeout_seconds:  "30"

<= module.smartschool-sync.data.template_file.redrive_policy
    rendered: "<computed>"
    template: "{\n  \"deadLetterTargetArn\":\"${dlq}\",\n  \"maxReceiveCount\":5\n}\n"
    vars.%:   "<computed>"
```
