### PR TITLE
Support for FIFO queues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,56 @@
 # terraform-sqs
+
 Terraform modules to set up SQS.
 
 ## sqs_with_iam
+
 Adds a iam profile and sqs queue.
 
 ### Available variables:
- * [`project`]: String(required): The project of this queue
- * [`environment`]: String(required): How do you want to call your environment, this is helpful if you have more than 1 VPC.
- * [`name`]: String(required): The name of the sqs queue
- * all other variables and description can be found in the variables.tf section
+
+* [`project`]: String(required): The project of this queue
+* [`environment`]: String(required): How do you want to call your environment, this is helpful if you have more than 1 VPC.
+* [`name`]: String(required): The name of the sqs queue
+* [`fifo_queue`]: Boolean(optional, defaults to `false`): Create a FIFO queue.
+  This will append the required extension `.fifo` to the queue name.
+* all other variables and description can be found in the variables.tf section
 
 ### Output
- * [`arn`]: String: The Amazon Resource Name (ARN) specifying the role.
- * [`id`]: String: The URL for the created Amazon SQS queue.
- * [`consumer_policy`]: String: The arn of the IAM policy used by the queue consumer / worker.
- * [`pusher_policy`]: String: The arn of the IAM policy used by the queue pusher.
 
-### Example
-```
+* [`arn`]: String: The Amazon Resource Name (ARN) specifying the role.
+* [`id`]: String: The URL for the created Amazon SQS queue.
+* [`consumer_policy`]: String: The arn of the IAM policy used by the queue consumer / worker.
+* [`pusher_policy`]: String: The arn of the IAM policy used by the queue pusher.
+
+### Examples
+
+*Standard queue*
+
+```hcl
   module "sqs" {
     source      = "github.com/skyscrapers/terraform-sqs//sqs_with_iam"
     environment = "${var.environment}"
-    project = "${var.project}"
-    name = "sqs_name"
+    project     = "${var.project}"
+    name        = "sqs_name"
   }
   resource "aws_iam_role_policy_attachment" "sqs-attach" {
-      role = "${module.instance.role}"
+      role       = "${module.instance.role}"
+      policy_arn = "${module.sqs_api.consumer_policy}"
+  }
+```
+
+*FIFO queue*
+
+```hcl
+  module "sqs" {
+    source      = "github.com/skyscrapers/terraform-sqs//sqs_with_iam"
+    environment = "${var.environment}"
+    project     = "${var.project}"
+    name        = "sqs_name"
+    fifo_queue  = "true"
+  }
+  resource "aws_iam_role_policy_attachment" "sqs-attach" {
+      role       = "${module.instance.role}"
       policy_arn = "${module.sqs_api.consumer_policy}"
   }
 ```

--- a/sqs_with_iam/main.tf
+++ b/sqs_with_iam/main.tf
@@ -13,11 +13,12 @@ EOF
 }
 
 resource "aws_sqs_queue" "queue" {
-  name                       = "${var.environment}_${var.project}_${var.name}"
+  name                       = "${var.environment}_${var.project}_${var.name}${var.fifo_queue == "true" ? ".fifo" : ""}"
   visibility_timeout_seconds = "${var.visibility_timeout_seconds}"
   delay_seconds              = "${var.delay_seconds}"
-  max_message_size           = "${var.max_message_size}"                                                                # 256 KB
-  message_retention_seconds  = "${var.message_retention_seconds}"                                                       # 4 days
+  max_message_size           = "${var.max_message_size}"                                                                 # 256 KB
+  message_retention_seconds  = "${var.message_retention_seconds}"                                                        # 4 days
   receive_wait_time_seconds  = "${var.receive_wait_time_seconds}"
   redrive_policy             = "${length(var.dead_letter_queue) > 0 ? data.template_file.redrive_policy.rendered : ""}"
+  fifo_queue                 = "${var.fifo_queue}"
 }

--- a/sqs_with_iam/variables.tf
+++ b/sqs_with_iam/variables.tf
@@ -38,3 +38,8 @@ variable "max_receive_count" {
   description = "Maximum receive count"
   default     = "5"
 }
+
+variable "fifo_queue" {
+  description = "Configure the queue to be a FIFO queue"
+  default     = "false"
+}


### PR DESCRIPTION
Add support for FIFO queues. This was being discussed with @venturel for Tablebooker. While eventually not directly needed, I was waiting for the Tablebooker PR to be approved and meanwhile added support for FIFO queues to the module:

I tested the correct functioning of my changes against the Tablebooker setup. Here is a plan output for a FIFO queue:

```
  + module.event_queue.aws_sqs_queue.queue
      id:                                <computed>
      arn:                               <computed>
      content_based_deduplication:       "false"
      delay_seconds:                     "0"
      fifo_queue:                        "true"
      kms_data_key_reuse_period_seconds: <computed>
      max_message_size:                  "262144"
      message_retention_seconds:         "345600"
      name:                              "staging_tablebooker_event.fifo"
      policy:                            <computed>
      receive_wait_time_seconds:         "20"
      visibility_timeout_seconds:        "30"
```