### PR TITLE
Completely refactor module

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ module "sqs" {
 
   for_each = toset(["myqueue"])
 
-  name                      = "${each.key}-${terraform.workspace}"
-  fifo_queue                = true
+  name       = "${each.key}-${terraform.workspace}"
+  fifo_queue = true
 }
 
 resource "aws_iam_role_policy_attachment" "sqs_consumer_attach" {

--- a/README.md
+++ b/README.md
@@ -6,31 +6,61 @@ Terraform modules to set up SQS.
 
 Adds a iam profile and sqs queue.
 
-### Available variables:
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws) | >= 3.48 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider_aws) | >= 3.48 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.consumer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.pusher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_sqs_queue.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [aws_iam_policy_document.consumer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.pusher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| dead_letter_queue | The dead letter queue to use for undeliverable messages | string | `` | no |
-| delay_seconds | Delay in displaying message | string | `0` | no |
-| environment | How do you want to call your environment, this is helpful if you have more than 1 VPC | string | - | yes |
-| fifo_queue | Configure the queue(s) to be FIFO queue(s). This will append the required extension `.fifo` to the queue name(s). | string | `false` | no |
-| max_message_size | Max size of the message default to 256KB | string | `262144` | no |
-| max_receive_count | Maximum receive count | string | `5` | no |
-| message_retention_seconds | Seconds of retention of the message default to 4 days | string | `345600` | no |
-| name | List of the SQS queue names. If you provide multiple names, each queue will be setup with the same configuration | list | - | yes |
-| project | The project of this queue(s) | string | - | yes |
-| receive_wait_time_seconds | The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning. An integer from 0 to 20 (seconds). The default for this attribute is 0, meaning that the call will return immediately. | string | `20` | no |
-| visibility_timeout_seconds | The timeout in seconds of visibility of the message | string | `30` | no |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input_name) | The SQS queue name | `string` | n/a | yes |
+| <a name="input_content_based_deduplication"></a> [content_based_deduplication](#input_content_based_deduplication) | Enables content-based deduplication for FIFO queues | `bool` | `false` | no |
+| <a name="input_dead_letter_queue"></a> [dead_letter_queue](#input_dead_letter_queue) | The dead letter queue to use for undeliverable messages | `string` | `null` | no |
+| <a name="input_deduplication_scope"></a> [deduplication_scope](#input_deduplication_scope) | Specifies whether message deduplication occurs at the message group or queue level. Valid values are `messageGroup` and `queue` (default) | `string` | `null` | no |
+| <a name="input_delay_seconds"></a> [delay_seconds](#input_delay_seconds) | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes). The default for this attribute is 0 seconds | `number` | `0` | no |
+| <a name="input_fifo_queue"></a> [fifo_queue](#input_fifo_queue) | Boolean designating a FIFO queue. If not set, it defaults to false making it standard. This will append the required extension `.fifo` to the queue name | `bool` | `false` | no |
+| <a name="input_fifo_throughput_limit"></a> [fifo_throughput_limit](#input_fifo_throughput_limit) | Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are `perQueue` (default) and `perMessageGroupId` | `string` | `null` | no |
+| <a name="input_kms_data_key_reuse_period_seconds"></a> [kms_data_key_reuse_period_seconds](#input_kms_data_key_reuse_period_seconds) | The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). The default is 300 (5 minutes) | `number` | `null` | no |
+| <a name="input_kms_master_key_id"></a> [kms_master_key_id](#input_kms_master_key_id) | The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK | `string` | `null` | no |
+| <a name="input_max_message_size"></a> [max_message_size](#input_max_message_size) | The limit of how many bytes a message can contain before Amazon SQS rejects it. An integer from 1024 bytes (1 KiB) up to 262144 bytes (256 KiB). The default for this attribute is 262144 (256 KiB) | `number` | `262144` | no |
+| <a name="input_max_receive_count"></a> [max_receive_count](#input_max_receive_count) | maxReceiveCount for the Dead Letter Queue redrive policy | `number` | `5` | no |
+| <a name="input_message_retention_seconds"></a> [message_retention_seconds](#input_message_retention_seconds) | The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days). The default for this attribute is 345600 (4 days) | `number` | `345600` | no |
+| <a name="input_receive_wait_time_seconds"></a> [receive_wait_time_seconds](#input_receive_wait_time_seconds) | The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning. An integer from 0 to 20 (seconds). The default for this attribute is 0, meaning that the call will return immediately | `number` | `0` | no |
+| <a name="input_tags"></a> [tags](#input_tags) | A map of tags to assign to the queue | `map(string)` | `null` | no |
+| <a name="input_visibility_timeout_seconds"></a> [visibility_timeout_seconds](#input_visibility_timeout_seconds) | The visibility timeout for the queue. An integer from 0 to 43200 (12 hours). The default for this attribute is 30. | `number` | `30` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|
-| arn | The Amazon Resource Name (ARN) specifying the role. |
-| consumer_policy | A list of the arns of the IAM policies used by the queue pusher. |
-| id | A list of URLs for the created Amazon SQS queues. |
-| pusher_policy | A list of the arns of the IAM policies used by the queue consumer / worker. |
-| queue_count | The number of queues to be created. To be used downstream |
+| <a name="output_arn"></a> [arn](#output_arn) | The ARN for the created Amazon SQS queue |
+| <a name="output_consumer_policy_arn"></a> [consumer_policy_arn](#output_consumer_policy_arn) | The ARN of the IAM policy used by the queue pusher |
+| <a name="output_id"></a> [id](#output_id) | The URL for the created Amazon SQS queue |
+| <a name="output_pusher_policy_arn"></a> [pusher_policy_arn](#output_pusher_policy_arn) | The ARN of the IAM policy used by the queue consumer / worker |
 
 ### Examples
 
@@ -38,33 +68,16 @@ Adds a iam profile and sqs queue.
 
 ```hcl
 module "sqs" {
-  source      = "github.com/skyscrapers/terraform-sqs//sqs_with_iam"
-  environment = "staging"
-  project     = "example"
-  name        = ["sqs_name"]
+  source = "github.com/skyscrapers/terraform-sqs//sqs_with_iam?ref=4.0.0"
+
+  for_each = toset(["myqueue"])
+
+  name                      = "${each.key}-${terraform.workspace}"
+  fifo_queue                = true
 }
 
-resource "aws_iam_role_policy_attachment" "sqs-attach" {
-  count      = "${module.sqs.queue_count}"
+resource "aws_iam_role_policy_attachment" "sqs_consumer_attach" {
   role       = "some_role_name"
-  policy_arn = "${module.sqs.consumer_policy[count.index]}"
-}
-```
-
-*FIFO queue*
-
-```hcl
-module "sqs" {
-  source      = "github.com/skyscrapers/terraform-sqs//sqs_with_iam"
-  environment = "staging"
-  project     = "example"
-  name        = ["sqs_name", "another_sqs_queue_name"]
-  fifo_queue  = "true"
-}
-
-resource "aws_iam_role_policy_attachment" "sqs-attach" {
-  count      = "${module.sqs.queue_count}"
-  role       = "some_role_name"
-  policy_arn = "${module.sqs.consumer_policy[count.index]}"
+  policy_arn = module.sqs["myqueue"].consumer_policy_arn
 }
 ```

--- a/sqs_with_iam/iam.tf
+++ b/sqs_with_iam/iam.tf
@@ -1,53 +1,38 @@
-resource "aws_iam_policy" "consumer_policy" {
-  count = length(var.name)
-  name  = "sqs_${var.name[count.index]}_${var.project}_${var.environment}_consumer"
+data "aws_iam_policy_document" "consumer" {
+  statement {
+    effect    = "Allow"
+    resources = [aws_sqs_queue.queue.arn]
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "sqs:GetQueueAttributes",
-        "sqs:GetQueueUrl",
-        "sqs:ReceiveMessage",
-        "sqs:DeleteMessage*",
-        "sqs:PurgeQueue",
-        "sqs:ChangeMessageVisibility*"
-      ],
-      "Resource": [
-        "${element(aws_sqs_queue.queue.*.arn, count.index)}"
-      ]
-    }
-  ]
-}
-EOF
-
+    actions = [
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage*",
+      "sqs:PurgeQueue",
+      "sqs:ChangeMessageVisibility*"
+    ]
+  }
 }
 
-resource "aws_iam_policy" "pusher_policy" {
-  count = length(var.name)
-  name = "sqs_${var.name[count.index]}_${var.project}_${var.environment}_pusher"
+data "aws_iam_policy_document" "pusher" {
+  statement {
+    effect    = "Allow"
+    resources = [aws_sqs_queue.queue.arn]
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "sqs:GetQueueAttributes",
-        "sqs:GetQueueUrl",
-        "sqs:SendMessage*"
-      ],
-      "Resource": [
-        "${element(aws_sqs_queue.queue.*.arn, count.index)}"
-      ]
-    }
-  ]
-}
-EOF
-
+    actions = [
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+      "sqs:SendMessage*"
+    ]
+  }
 }
 
+resource "aws_iam_policy" "consumer" {
+  name   = "sqs-${var.name}-consumer"
+  policy = data.aws_iam_policy_document.consumer.json
+}
+
+resource "aws_iam_policy" "pusher" {
+  name   = "sqs-${var.name}-pusher"
+  policy = data.aws_iam_policy_document.pusher.json
+}

--- a/sqs_with_iam/main.tf
+++ b/sqs_with_iam/main.tf
@@ -1,26 +1,27 @@
-data "template_file" "redrive_policy" {
-  template = <<EOF
-{
-  "deadLetterTargetArn":"$${dlq}",
-  "maxReceiveCount":$${mrc}
-}
-EOF
-
-
-  vars = {
-    dlq = var.dead_letter_queue
-    mrc = var.max_receive_count
-  }
+locals {
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = var.dead_letter_queue
+    maxReceiveCount     = var.max_receive_count
+  })
 }
 
 resource "aws_sqs_queue" "queue" {
-  count = length(var.name)
-  name = "${var.environment}_${var.project}_${var.name[count.index]}${var.fifo_queue == "true" ? ".fifo" : ""}"
+  name = "${var.name}${var.fifo_queue ? ".fifo" : ""}"
+  tags = var.tags
+
   visibility_timeout_seconds = var.visibility_timeout_seconds
-  delay_seconds = var.delay_seconds
-  max_message_size = var.max_message_size # 256 KB
-  message_retention_seconds = var.message_retention_seconds # 4 days
-  receive_wait_time_seconds = var.receive_wait_time_seconds
-  redrive_policy = length(var.dead_letter_queue) > 0 ? data.template_file.redrive_policy.rendered : ""
-  fifo_queue = var.fifo_queue
+  message_retention_seconds  = var.message_retention_seconds
+  max_message_size           = var.max_message_size
+  delay_seconds              = var.delay_seconds
+  receive_wait_time_seconds  = var.receive_wait_time_seconds
+
+  redrive_policy = var.dead_letter_queue != null ? local.redrive_policy : null
+
+  fifo_queue                  = var.fifo_queue
+  fifo_throughput_limit       = var.fifo_throughput_limit
+  content_based_deduplication = var.content_based_deduplication
+  deduplication_scope         = var.deduplication_scope
+
+  kms_master_key_id                 = var.kms_master_key_id
+  kms_data_key_reuse_period_seconds = var.kms_data_key_reuse_period_seconds
 }

--- a/sqs_with_iam/output.tf
+++ b/sqs_with_iam/output.tf
@@ -1,24 +1,19 @@
 output "arn" {
-  value       = aws_sqs_queue.queue.*.arn
-  description = "The Amazon Resource Name (ARN) specifying the role."
+  value       = aws_sqs_queue.queue.arn
+  description = "The ARN for the created Amazon SQS queue"
 }
 
 output "id" {
-  value       = aws_sqs_queue.queue.*.id
-  description = "The URL for the created Amazon SQS queue."
+  value       = aws_sqs_queue.queue.id
+  description = "The URL for the created Amazon SQS queue"
 }
 
-output "pusher_policy" {
-  value       = aws_iam_policy.pusher_policy.*.arn
-  description = "A list of the arns of the IAM policies used by the queue consumer / worker."
+output "pusher_policy_arn" {
+  value       = aws_iam_policy.pusher.arn
+  description = "The ARN of the IAM policy used by the queue consumer / worker"
 }
 
-output "consumer_policy" {
-  value       = aws_iam_policy.consumer_policy.*.arn
-  description = "A list of the arns of the IAM policies used by the queue pusher."
-}
-
-output "queue_count" {
-  value       = length(var.name)
-  description = "The number of queues to be created. To be used downstream"
+output "consumer_policy_arn" {
+  value       = aws_iam_policy.consumer.arn
+  description = "The ARN of the IAM policy used by the queue pusher"
 }

--- a/sqs_with_iam/variables.tf
+++ b/sqs_with_iam/variables.tf
@@ -1,53 +1,88 @@
-variable "environment" {
-  description = "How do you want to call your environment, this is helpful if you have more than 1 VPC"
-}
-
-variable "project" {
-  description = "The project of this queue(s)"
-}
-
 variable "name" {
-  description = "List of the SQS queue names. If you provide multiple names, each queue will be setup with the same configuration"
-  type        = list(string)
+  type        = string
+  description = "The SQS queue name"
 }
 
 variable "visibility_timeout_seconds" {
-  description = "The timeout in seconds of visibility of the message"
+  type        = number
+  description = "The visibility timeout for the queue. An integer from 0 to 43200 (12 hours). The default for this attribute is 30."
   default     = 30
 }
 
-variable "delay_seconds" {
-  description = "Delay in displaying message"
-  default     = "0"
+variable "message_retention_seconds" {
+  type        = number
+  description = "The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days). The default for this attribute is 345600 (4 days)"
+  default     = 345600
 }
 
 variable "max_message_size" {
-  description = "Max size of the message default to 256KB"
-  default     = "262144"
+  type        = number
+  description = "The limit of how many bytes a message can contain before Amazon SQS rejects it. An integer from 1024 bytes (1 KiB) up to 262144 bytes (256 KiB). The default for this attribute is 262144 (256 KiB)"
+  default     = 262144
 }
 
-variable "message_retention_seconds" {
-  description = "Seconds of retention of the message default to 4 days"
-  default     = "345600"
+variable "delay_seconds" {
+  type        = number
+  description = "The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes). The default for this attribute is 0 seconds"
+  default     = 0
 }
 
 variable "receive_wait_time_seconds" {
-  description = "The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning. An integer from 0 to 20 (seconds). The default for this attribute is 0, meaning that the call will return immediately."
-  default     = "20"
+  type        = number
+  description = "The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning. An integer from 0 to 20 (seconds). The default for this attribute is 0, meaning that the call will return immediately"
+  default     = 0
 }
 
 variable "dead_letter_queue" {
+  type        = string
   description = "The dead letter queue to use for undeliverable messages"
-  default     = ""
+  default     = null
 }
 
 variable "max_receive_count" {
-  description = "Maximum receive count"
-  default     = "5"
+  type        = number
+  description = "maxReceiveCount for the Dead Letter Queue redrive policy"
+  default     = 5
 }
 
 variable "fifo_queue" {
-  description = "Configure the queue(s) to be FIFO queue(s). This will append the required extension `.fifo` to the queue name(s)."
-  default     = "false"
+  type        = bool
+  description = "Boolean designating a FIFO queue. If not set, it defaults to false making it standard. This will append the required extension `.fifo` to the queue name"
+  default     = false
 }
 
+variable "content_based_deduplication" {
+  type        = bool
+  description = "Enables content-based deduplication for FIFO queues"
+  default     = false
+}
+
+variable "deduplication_scope" {
+  type        = string
+  description = "Specifies whether message deduplication occurs at the message group or queue level. Valid values are `messageGroup` and `queue` (default)"
+  default     = null
+}
+
+variable "fifo_throughput_limit" {
+  type        = string
+  description = "Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are `perQueue` (default) and `perMessageGroupId`"
+  default     = null
+}
+
+variable "kms_master_key_id" {
+  type        = string
+  description = "The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK"
+  default     = null
+}
+
+variable "kms_data_key_reuse_period_seconds" {
+  type        = number
+  description = "The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). The default is 300 (5 minutes)"
+  default     = null
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to assign to the queue"
+  default     = null
+}

--- a/sqs_with_iam/versions.tf
+++ b/sqs_with_iam/versions.tf
@@ -1,4 +1,10 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.48"
+    }
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
This PR rewrites our `sqs_with_iam` module, mostly simplifying it and leveraging module `for_each` support instead of relying on counts.

This is a breaking change and manual steps are needed to migrate existing TF state if you wish to use this newish module.

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/skyscrapers/engineering/issues/#488
https://github.com/skyscrapers/neanex/issues/447

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Applied several times.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
