### PR TITLE
Fix IAM document without KMS

### DIFF
--- a/sqs_with_iam/iam.tf
+++ b/sqs_with_iam/iam.tf
@@ -13,13 +13,17 @@ data "aws_iam_policy_document" "consumer" {
     ]
   }
 
-  statement {
-    effect    = "Allow"
-    resources = [var.kms_master_key_id]
+  dynamic "statement" {
+    for_each = var.kms_master_key_id != null ? [1] : []
 
-    actions = [
-      "kms:Decrypt"
-    ]
+    content {
+      effect    = "Allow"
+      resources = [var.kms_master_key_id]
+
+      actions = [
+        "kms:Decrypt"
+      ]
+    }
   }
 }
 
@@ -35,14 +39,18 @@ data "aws_iam_policy_document" "pusher" {
     ]
   }
 
-  statement {
-    effect    = "Allow"
-    resources = [var.kms_master_key_id]
+  dynamic "statement" {
+    for_each = var.kms_master_key_id != null ? [1] : []
 
-    actions = [
-      "kms:GenerateDataKey",
-      "kms:Decrypt"
-    ]
+    content {
+      effect    = "Allow"
+      resources = [var.kms_master_key_id]
+
+      actions = [
+        "kms:GenerateDataKey",
+        "kms:Decrypt"
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->

Fixes error introduced with latest release, when no KMS key is specified.

```
│ Error: Null value found in list
│
│   with module.sqs_data_handler.data.aws_iam_policy_document.consumer,
│   on .terraform/modules/sqs_data_handler/sqs_with_iam/iam.tf line 18, in data "aws_iam_policy_document" "consumer":
│   18:     resources = [var.kms_master_key_id]
│
│ Null values are not allowed for this attribute value.
```

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
/

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Applied

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
